### PR TITLE
Fix REPL for godot 4.x

### DIFF
--- a/gdrepl/gdserverv4.gd
+++ b/gdrepl/gdserverv4.gd
@@ -244,7 +244,6 @@ func _init():
     port = OS.get_environment("PORT").to_int()
 
 
-  # We dont need those but good to know
   _server.message_received.connect(_on_message)
 
   # Start listening on the given port.

--- a/gdrepl/gdserverv4.gd
+++ b/gdrepl/gdserverv4.gd
@@ -3,6 +3,8 @@
 
 extends SceneTree
 
+const WebSocketServer = preload("websocketserver.gd")
+
 # Simple protocol:
 # Send anything else to evaluate as godot code
 # Commands:
@@ -243,7 +245,7 @@ func _init():
 
 
   # We dont need those but good to know
-  _server.data_received.connect(_on_data)
+  _server.message_received.connect(_on_message)
 
   # Start listening on the given port.
   var err = _server.listen(port)
@@ -304,11 +306,9 @@ func test():
   debug = false
 
 
-func _on_data(id):
-  var pkt = _server.get_peer(id).get_packet()
-  var data = pkt.get_string_from_utf8()
+func _on_message(id, message):
   if debug:
-    print("Got data from client %d: %s" % [id, data])
+    print("Got message from client %d: %s" % [id, message])
 
   var session = "main"
   if OS.has_environment("SESSION") and session == "main":
@@ -316,7 +316,7 @@ func _on_data(id):
 
 
   # Commands without arguments
-  var cmd = data.strip_edges().to_lower()
+  var cmd = message.strip_edges().to_lower()
   var response = ""
   var has_command = true
   match cmd :
@@ -366,18 +366,18 @@ func _on_data(id):
     return
 
   # Commands with arguments
-  cmd = data.strip_edges().split(" ")[0].to_lower()
+  cmd = message.strip_edges().split(" ")[0].to_lower()
   match cmd:
     "delline_local":
-      sessions[session].dellocal((data.split(" ")[1]).to_int())
+      sessions[session].dellocal((message.split(" ")[1]).to_int())
       response = "Deleted line"
 
     "delline_global":
-      sessions[session].delglobal((data.split(" ")[1]).to_int())
+      sessions[session].delglobal((message.split(" ")[1]).to_int())
       response = "Deleted line"
 
     _:
-      response = exec(data, session)
+      response = exec(message, session)
       send(id, ">> " + response)
       return
 
@@ -385,8 +385,7 @@ func _on_data(id):
 
 
 func send(id, data):
-  _server.get_peer(id).put_packet(data.to_utf8_buffer())
-
+  _server.peers.get(id).put_packet(data.to_utf8_buffer())
 
 func _process(_delta):
   _server.poll()

--- a/gdrepl/websocketserver.gd
+++ b/gdrepl/websocketserver.gd
@@ -1,0 +1,184 @@
+# Copyright (c) 2014-present Godot Engine contributors.
+# Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# Example taken from https://github.com/godotengine/godot-demo-projects/blob/c3b0331d8a06a2b8def14e745db9e24d0f387c80/networking/websocket_minimal/server.gd Modified to include copyright notice
+
+class_name WebSocketServer
+extends Node
+
+signal message_received(peer_id: int, message: String)
+signal client_connected(peer_id: int)
+signal client_disconnected(peer_id: int)
+
+@export var handshake_headers := PackedStringArray()
+@export var supported_protocols := PackedStringArray()
+@export var handshake_timout := 3000
+@export var use_tls := false
+@export var tls_cert: X509Certificate
+@export var tls_key: CryptoKey
+@export var refuse_new_connections := false:
+	set(refuse):
+		if refuse:
+			pending_peers.clear()
+
+
+class PendingPeer:
+	var connect_time: int
+	var tcp: StreamPeerTCP
+	var connection: StreamPeer
+	var ws: WebSocketPeer
+
+	func _init(p_tcp: StreamPeerTCP) -> void:
+		tcp = p_tcp
+		connection = p_tcp
+		connect_time = Time.get_ticks_msec()
+
+
+var tcp_server := TCPServer.new()
+var pending_peers: Array[PendingPeer] = []
+var peers: Dictionary
+
+
+func listen(port: int) -> int:
+	assert(not tcp_server.is_listening())
+	return tcp_server.listen(port)
+
+
+func stop() -> void:
+	tcp_server.stop()
+	pending_peers.clear()
+	peers.clear()
+
+
+func send(peer_id: int, message: String) -> int:
+	var type := typeof(message)
+	if peer_id <= 0:
+		# Send to multiple peers, (zero = broadcast, negative = exclude one).
+		for id: int in peers:
+			if id == -peer_id:
+				continue
+			if type == TYPE_STRING:
+				peers[id].send_text(message)
+			else:
+				peers[id].put_packet(message)
+		return OK
+
+	assert(peers.has(peer_id))
+	var socket: WebSocketPeer = peers[peer_id]
+	if type == TYPE_STRING:
+		return socket.send_text(message)
+	return socket.send(var_to_bytes(message))
+
+
+func get_message(peer_id: int) -> Variant:
+	assert(peers.has(peer_id))
+	var socket: WebSocketPeer = peers[peer_id]
+	if socket.get_available_packet_count() < 1:
+		return null
+	var pkt: PackedByteArray = socket.get_packet()
+	if socket.was_string_packet():
+		return pkt.get_string_from_utf8()
+	return bytes_to_var(pkt)
+
+
+func has_message(peer_id: int) -> bool:
+	assert(peers.has(peer_id))
+	return peers[peer_id].get_available_packet_count() > 0
+
+
+func _create_peer() -> WebSocketPeer:
+	var ws := WebSocketPeer.new()
+	ws.supported_protocols = supported_protocols
+	ws.handshake_headers = handshake_headers
+	return ws
+
+
+func poll() -> void:
+	if not tcp_server.is_listening():
+		return
+
+	while not refuse_new_connections and tcp_server.is_connection_available():
+		var conn: StreamPeerTCP = tcp_server.take_connection()
+		assert(conn != null)
+		pending_peers.append(PendingPeer.new(conn))
+
+	var to_remove := []
+
+	for p in pending_peers:
+		if not _connect_pending(p):
+			if p.connect_time + handshake_timout < Time.get_ticks_msec():
+				# Timeout.
+				to_remove.append(p)
+			continue  # Still pending.
+
+		to_remove.append(p)
+
+	for r: RefCounted in to_remove:
+		pending_peers.erase(r)
+
+	to_remove.clear()
+
+	for id: int in peers:
+		var p: WebSocketPeer = peers[id]
+		p.poll()
+
+		if p.get_ready_state() != WebSocketPeer.STATE_OPEN:
+			client_disconnected.emit(id)
+			to_remove.append(id)
+			continue
+
+		while p.get_available_packet_count():
+			message_received.emit(id, get_message(id))
+
+	for r: int in to_remove:
+		peers.erase(r)
+	to_remove.clear()
+
+
+func _connect_pending(p: PendingPeer) -> bool:
+	if p.ws != null:
+		# Poll websocket client if doing handshake.
+		p.ws.poll()
+		var state := p.ws.get_ready_state()
+		if state == WebSocketPeer.STATE_OPEN:
+			var id := randi_range(2, 1 << 30)
+			peers[id] = p.ws
+			client_connected.emit(id)
+			return true  # Success.
+		elif state != WebSocketPeer.STATE_CONNECTING:
+			return true  # Failure.
+		return false  # Still connecting.
+	elif p.tcp.get_status() != StreamPeerTCP.STATUS_CONNECTED:
+		return true  # TCP disconnected.
+	elif not use_tls:
+		# TCP is ready, create WS peer.
+		p.ws = _create_peer()
+		p.ws.accept_stream(p.tcp)
+		return false  # WebSocketPeer connection is pending.
+
+	else:
+		if p.connection == p.tcp:
+			assert(tls_key != null and tls_cert != null)
+			var tls := StreamPeerTLS.new()
+			tls.accept_stream(p.tcp, TLSOptions.server(tls_key, tls_cert))
+			p.connection = tls
+		p.connection.poll()
+		var status: StreamPeerTLS.Status = p.connection.get_status()
+		if status == StreamPeerTLS.STATUS_CONNECTED:
+			p.ws = _create_peer()
+			p.ws.accept_stream(p.connection)
+			return false  # WebSocketPeer connection is pending.
+		if status != StreamPeerTLS.STATUS_HANDSHAKING:
+			return true  # Failure.
+
+		return false
+
+
+func _process(_delta: float) -> void:
+	poll()


### PR DESCRIPTION
## What

Fixes the  error `SCRIPT ERROR: Parse Error: Identifier "WebSocketServer" not declared in the current scope.`

Tested in godot `4.2`, but I believe this is applicable to most/all release versions of Godot 4.x [based on this github issue](https://github.com/godotengine/godot-docs/issues/7116).

## Why

`WebSocketServer` was removed in favor of using the lower-level `WebSocketPeer` + `TCPServer`. From a game-dev perspective, this makes a lot of sense, but really messed this particular project up.